### PR TITLE
s4/tests: fix build failure against gcc-10

### DIFF
--- a/tests/s4/t_s4.c
+++ b/tests/s4/t_s4.c
@@ -27,8 +27,8 @@ CLEANUP () {
 	return 0;
 }
 
-char *name;
-s4_t *s4;
+static char *name;
+static s4_t *s4;
 
 static void _mem_open (void)
 {

--- a/tests/s4/t_transactions.c
+++ b/tests/s4/t_transactions.c
@@ -19,8 +19,8 @@
 #include <glib.h>
 #include <glib/gstdio.h>
 
-s4_t *s4;
-s4_val_t *val;
+static s4_t *s4;
+static s4_val_t *val;
 
 SETUP (Transactions) {
 	val = s4_val_new_int (1);


### PR DESCRIPTION
On gcc-10 (and gcc-9 -fno-common) build fails as:

```
ld: tests/s4/t_transactions.c.2.o:/tests/s4/t_transactions.c:22:
  multiple definition of `s4'; tests/s4/t_s4.c.2.o:tests/s4/t_s4.c:31: first defined here
collect2: error: ld returned 1 exit status
Waf: Leaving directory `/home/slyfox/dev/git/s4/_build_'
Build failed
 -> task in 'test_s4' failed (exit status 1):
```

gcc-10 will change the default from -fcommon to fno-common:
https://gcc.gnu.org/PR85678.

The error also happens if CFLAGS=-fno-common passed explicitly.

Reported-by: Toralf Förster
Bug: https://bugs.gentoo.org/706940