### PR TITLE
OTHER: s4/wcript: port 'check_cc()' to 'fragment='

### DIFF
--- a/src/tools/s4/wscript
+++ b/src/tools/s4/wscript
@@ -40,9 +40,16 @@ def configure (conf):
     conf.load("bison")
     conf.env.append_value('BISONFLAGS', '--verbose')
 
+    fragment="""
+    #include <stdio.h>
+    #include <readline/readline.h>
+    int main(void) {
+        return readline("prompt") != 0;
+    }
+    """
     rl_headers=["stdio.h", "readline/readline.h"]
     conf.check_cc(header_name=rl_headers)
-    conf.check_cc(lib="readline", header_name=rl_headers, function_name='readline',
+    conf.check_cc(lib="readline", header_name=rl_headers, fragment=fragment,
             uselib_store="readline")
     # Check support for %destructor in bison (bug 2594)
     conf.check_cc(fragment=bison_fragment, compile_filename="fragment.y")


### PR DESCRIPTION
Recent waf versions dropped support for 'check_cc(function_name=)'
which causes errors and warning during ./waf configure:

    Invalid argument 'function_name' in test

(Done as part of https://gitlab.com/ita1024/waf/-/issues/2204).

The change switcher to more verbose (and more robust)
'check_cc(fragment=' equivalent.